### PR TITLE
Fix silent errors

### DIFF
--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -32,6 +32,7 @@ describe('webpack preprocessor', function () {
     webpack.returns(this.compilerApi)
 
     this.statsApi = {
+      hasErrors () { return false },
       toJson () { return { warnings: [], errors: [] } },
     }
 
@@ -168,10 +169,22 @@ describe('webpack preprocessor', function () {
         }
       })
 
-      it('it rejects with error', function () {
+      it('it rejects with error when an err', function () {
         this.compilerApi.run.yields(this.err)
         return this.run().catch((err) => {
           expect(err.stack).to.equal(this.err.stack)
+        })
+      })
+
+      it('it rejects with joined errors when a stats err', function () {
+        const errs = ['foo', 'bar', 'baz']
+        this.statsApi = {
+          hasErrors () { return true },
+          toJson () { return { errors: errs } },
+        }
+        this.compilerApi.run.yields(null, this.statsApi)
+        return this.run().catch((err) => {
+          expect(err.stack).to.equal(errs.join('\n\n'))
         })
       })
 


### PR DESCRIPTION
Fixes #8 

Webpack has 2 kinds of errors when compiling. It can outright fail with a an error or it can include what the documentation used to call 'soft errors' in a stats object. I previously ignored the soft errors because the one example I had seen didn't seem to warrant failing outright (I can't currently recall exactly what that error was). However, since having a missing dependency ends up as a soft error, which in reality completely breaks compilation, it makes sense to have soft errors fail the compilation so the error gets properly bubbled up and reported to the user.