### PR TITLE
URL for plugins in documentation has change

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This plugin (and all Cypress plugins) run in Cypress's own version of Node. If y
 
 ## Usage
 
-In your project's [plugins file](https://on.cypress.io/guides/guides/plugins.html):
+In your project's [plugins file](https://docs.cypress.io/plugins/index.html#content):
 
 ```javascript
 const webpack = require('@cypress/webpack-preprocessor')


### PR DESCRIPTION
The link to plugins in cypress documentations has change https://docs.cypress.io/plugins/index.html#content 🤓