### PR TITLE
Upgrade to Babel 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const defaultOptions = {
             {
               loader: require.resolve('babel-loader'),
               options: {
-                presets: ['babel-preset-env', 'babel-preset-react'].map(require.resolve),
+                presets: ['@babel/preset-env', '@babel/preset-react'].map(require.resolve),
               },
             },
           ],
@@ -146,9 +146,7 @@ const preprocessor = (options = {}) => {
       log('watching')
     }
 
-    const bundler = file.shouldWatch
-      ? compiler.watch(watchOptions, handle)
-      : compiler.run(handle)
+    const bundler = file.shouldWatch ? compiler.watch(watchOptions, handle) : compiler.run(handle)
 
     // when the spec or project is closed, we need to clean up the cached
     // bundle promise and stop the watcher via `bundler.close()`

--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
     "sinon-chai": "2.13.0"
   },
   "dependencies": {
-    "babel-core": "6.26.0",
-    "babel-loader": "7.1.4",
-    "babel-preset-env": "1.6.0",
-    "babel-preset-react": "6.24.1",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.0",
     "bluebird": "3.5.0",
     "debug": "3.1.0",
     "lodash.clonedeep": "4.5.0",


### PR DESCRIPTION

This PR updates some dependencies and changes a few strings for this project to use Babel 7.

### Why?
As Babel 7 was [officially out of a long beta a few days ago](https://babeljs.io/blog/2018/08/27/7.0.0), we decided to upgrade our project.

Upon peering into our CI, however, we encountered a Cypruss problem due mis-expectations in Babel versions.

```
Oops...we found an error preparing this test file:

  cypress/support/index.js

The error was:

./cypress/support/index.js
Module build failed (from /home/circleci/project/node_modules/@cypress/webpack-preprocessor/node_modules/babel-loader/lib/index.js):
Error: Requires Babel "^7.0.0-0", but was loaded with "6.26.0". If you are sure you have a compatible version of @babel/core, it is likely that something in your build process is loading the wrong version. Inspect the stack trace of this error to look for the first entry that doesn't mention "@babel/core" or "babel-core" to see what is calling Babel.
```

These changes should bring the project back into current and future community expectations.

![thing](https://user-images.githubusercontent.com/5721314/44792126-1b3c0900-ab9b-11e8-9862-3006b1ad2d40.gif)
