### PR TITLE
Move external resources to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,7 @@ Object of webpack options. Just `require` in the options from your `webpack.conf
         use: [{
           loader: 'babel-loader',
           options: {
-            presets: [
-              'babel-preset-env',
-              'babel-preset-react',
-            ],
+            presets: ['babel-preset-env'],
           },
         }],
       },

--- a/README.md
+++ b/README.md
@@ -8,9 +8,22 @@ Cypress preprocessor for bundling JavaScript via webpack
 npm install --save-dev @cypress/webpack-preprocessor
 ```
 
+This package relies on the following [peer dependencies](https://docs.npmjs.com/files/package.json#peerdependencies):
+
+* @babel/core
+* @babel/preset-env
+* babel-loader
+* webpack
+
+It is likely you already have these installed either directly or as a transient dependency, but if not, you will need to install them.
+
+```sh
+npm install --save-dev @babel/core @babel/preset-env babel-loader webpack
+```
+
 ## Compatibility
 
-This version is only compatible with webpack 4.x+ and Babel 7.x+. 
+This version is only compatible with webpack 4.x+ and Babel 7.x+.
 
 * If you need webpack 2 or 3 support, use `@cypress/webpack-preprocessor` 1.x
 * If you need Babel 6 support, use `@cypress/webpack-preprocessor` <= 2.x

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const defaultOptions = {
             {
               loader: require.resolve('babel-loader'),
               options: {
-                presets: ['@babel/preset-env', '@babel/preset-react'].map(require.resolve),
+                presets: require.resolve('@babel/preset-env'),
               },
             },
           ],

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "peerDependencies": {
     "@babel/core": "^7.0.1",
     "@babel/preset-env": "^7.0.0",
-    "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.2",
     "webpack": "^4.18.1"
   },

--- a/package.json
+++ b/package.json
@@ -54,15 +54,17 @@
     "sinon": "3.2.1",
     "sinon-chai": "2.13.0"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.0.1",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.2",
+    "webpack": "^4.18.1"
+  },
   "dependencies": {
-    "@babel/core": "7.0.1",
-    "@babel/preset-env": "7.0.0",
-    "@babel/preset-react": "7.0.0",
-    "babel-loader": "8.0.2",
     "bluebird": "3.5.0",
     "debug": "3.1.0",
-    "lodash.clonedeep": "4.5.0",
-    "webpack": "4.18.1"
+    "lodash.clonedeep": "4.5.0"
   },
   "release": {
     "verifyConditions": "condition-circle",


### PR DESCRIPTION
There's no need to set these as explicit dependencies as they're not used internally in a significant way, but to mirror the behavior of the user's libraries.  So in nearly ever case the user will already have a different version of these libraries as dependencies.  In the case that they do not, they will be prompted to install them.  This drastically reduces the dependencies for any project that is not upgrading their babel/webpack in line with what this library is hard set to.