### PR TITLE
fix default config to only require babel-loader and @babel/preset-env if there is no override

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Object of webpack options. Just `require` in the options from your `webpack.conf
   module: {
     rules: [
       {
-        test: /\.jsx?$/,
+        test: /\.js?$/,
         exclude: [/node_modules/],
         use: [{
           loader: 'babel-loader',

--- a/index.js
+++ b/index.js
@@ -7,24 +7,28 @@ const createDeferred = require('./deferred')
 
 const bundles = {}
 
+const defaultBabelLoaderRules = () => {
+  return [
+      {
+        test: /\.jsx?$/,
+        exclude: [/node_modules/],
+        use: [
+          {
+            loader: require.resolve('babel-loader'),
+            options: {
+              presets: require.resolve('@babel/preset-env'),
+            },
+          },
+        ],
+      },
+    ]
+}
+
 // by default, we transform JavaScript (up to anything at stage-4) and JSX
 const defaultOptions = {
   webpackOptions: {
     module: {
-      rules: [
-        {
-          test: /\.jsx?$/,
-          exclude: [/node_modules/],
-          use: [
-            {
-              loader: require.resolve('babel-loader'),
-              options: {
-                presets: require.resolve('@babel/preset-env'),
-              },
-            },
-          ],
-        },
-      ],
+      rules: [],
     },
   },
   watchOptions: {},
@@ -63,6 +67,9 @@ const preprocessor = (options = {}) => {
 
     // user can override the default options
     let webpackOptions = Object.assign({}, defaultOptions.webpackOptions, options.webpackOptions)
+    if (webpackOptions.module.rules === defaultOptions.webpackOptions) {
+      webpackOptions.module.rules = defaultBabelLoaderRules()
+    }
     let watchOptions = Object.assign({}, defaultOptions.watchOptions, options.watchOptions)
 
     // we're provided a default output path that lives alongside Cypress's

--- a/index.js
+++ b/index.js
@@ -184,7 +184,15 @@ const preprocessor = (options = {}) => {
   }
 }
 
-// provide a clone of the default options
-preprocessor.defaultOptions = cloneDeep(defaultOptions)
+// provide a clone of the default options, making sure to lazy-load
+// babel dependencies so that they aren't required unless the user
+// utilizes them
+Object.defineProperty(preprocessor, 'defaultOptions', {
+  get () {
+    const clonedDefaults = cloneDeep(defaultOptions)
+    clonedDefaults.webpackOptions.module.rules = defaultBabelLoaderRules()
+    return clonedDefaults
+  },
+})
 
 module.exports = preprocessor

--- a/index.js
+++ b/index.js
@@ -7,23 +7,26 @@ const createDeferred = require('./deferred')
 
 const bundles = {}
 
+// by default, we transform JavaScript supported by @babel/preset-env
 const defaultBabelLoaderRules = () => {
   return [
-      {
-        exclude: [/node_modules/],
-        use: [
-          {
-            loader: require.resolve('babel-loader'),
-            options: {
-              presets: require.resolve('@babel/preset-env'),
-            },
+    {
       test: /\.js?$/,
+      exclude: [/node_modules/],
+      use: [
+        {
+          loader: require.resolve('babel-loader'),
+          options: {
+            presets: require.resolve('@babel/preset-env'),
           },
-        ],
-      },
-    ]
+        },
+      ],
+    },
+  ]
 }
 
+// we don't automatically load the rules, so that the babel dependencies are
+// not required if a user passes in their own configuration
 const defaultOptions = {
   webpackOptions: {
     module: {
@@ -66,6 +69,8 @@ const preprocessor = (options = {}) => {
 
     // user can override the default options
     let webpackOptions = Object.assign({}, defaultOptions.webpackOptions, options.webpackOptions)
+    // here is where we load the default rules if the user has not passed
+    // in their own configuration
     if (webpackOptions.module.rules === defaultOptions.webpackOptions) {
       webpackOptions.module.rules = defaultBabelLoaderRules()
     }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ const bundles = {}
 const defaultBabelLoaderRules = () => {
   return [
       {
-        test: /\.jsx?$/,
         exclude: [/node_modules/],
         use: [
           {
@@ -18,13 +17,13 @@ const defaultBabelLoaderRules = () => {
             options: {
               presets: require.resolve('@babel/preset-env'),
             },
+      test: /\.js?$/,
           },
         ],
       },
     ]
 }
 
-// by default, we transform JavaScript (up to anything at stage-4) and JSX
 const defaultOptions = {
   webpackOptions: {
     module: {

--- a/package.json
+++ b/package.json
@@ -59,10 +59,12 @@
     "webpack": "^4.18.1"
   },
   "peerDependencies": {
+    "webpack": "^4.18.1"
+  },
+  "optionalDependencies": {
     "@babel/core": "^7.0.1",
     "@babel/preset-env": "^7.0.0",
-    "babel-loader": "^8.0.2",
-    "webpack": "^4.18.1"
+    "babel-loader": "^8.0.2"
   },
   "dependencies": {
     "bluebird": "3.5.0",


### PR DESCRIPTION
fix default config to only require babel-loader and @babel/preset-env if there is no override

Fixes #37