### PR TITLE
Update link to deleted webpack v1 docs to v4 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Source maps are always enabled unless explicitly disabled by specifying `devtool
 
 ### watchOptions
 
-Object of options for watching. See [webpack's docs](https://webpack.github.io/docs/node.js-api.html#compiler).
+Object of options for watching. See [webpack's docs](https://webpack.js.org/configuration/watch).
 
 **Default**: `{}`
 


### PR DESCRIPTION
Webpack v1 docs are dead. Since this library is [peering with v4](https://github.com/cypress-io/cypress-webpack-preprocessor/blob/master/package.json#L62), refer to the v4 docs instead.