### PR TITLE
fix: fix compilation error message

### DIFF
--- a/__snapshots__/e2e.spec.js
+++ b/__snapshots__/e2e.spec.js
@@ -25,14 +25,14 @@ The error was:
 Error: Webpack Compilation Error
 ./cypress/tests/e2e/compile-error.js
 Module build failed (from ./node_modules/babel-loader/lib/index.js):
-SyntaxError: /[cwd]/cypress/tests/e2e/compile-error.js: Unexpected token, expected "," (12:27)
+SyntaxError: /[cwd]/cypress/tests/e2e/compile-error.js: Unexpected token, expected "," (14:27)
 
-  10 | 
-  11 | describe('foo', ()=>{
-> 12 |   it('has syntax error' () => {}})
+  12 | 
+  13 | describe('foo', ()=>{
+> 14 |   it('has syntax error' () => {}})
      |                            ^
-  13 | })
-  14 | 
+  15 | })
+  16 | 
 
  @ multi ./cypress/tests/e2e/compile-error.js main[0]
 

--- a/__snapshots__/e2e.spec.js
+++ b/__snapshots__/e2e.spec.js
@@ -22,6 +22,7 @@ Oops...we found an error preparing this test file:
 
 The error was:
 
+Error: Webpack Compilation Error
 ./cypress/tests/e2e/compile-error.js
 Module build failed (from ./node_modules/babel-loader/lib/index.js):
 SyntaxError: /[cwd]/cypress/tests/e2e/compile-error.js: Unexpected token, expected "," (12:27)
@@ -34,6 +35,7 @@ SyntaxError: /[cwd]/cypress/tests/e2e/compile-error.js: Unexpected token, expect
   14 | 
 
  @ multi ./cypress/tests/e2e/compile-error.js main[0]
+
 
 This occurred while Cypress was compiling and bundling your test code. This is usually caused by:
 

--- a/cypress/tests/e2e/compile-error.js
+++ b/cypress/tests/e2e/compile-error.js
@@ -5,7 +5,9 @@
 /* EXPECT: {
   expectedResults: {
     totalFailed: 1
-  }
+  },
+  // https://github.com/cypress-io/cypress-webpack-preprocessor/issues/64
+  stdoutInclude: 'Webpack Compilation Error'
 } */
 
 describe('foo', ()=>{

--- a/index.js
+++ b/index.js
@@ -123,11 +123,14 @@ const preprocessor = (options = {}) => {
 
       if (stats.hasErrors()) {
         err = new Error('Webpack Compilation Error')
-        err.message += `\n${jsonStats.errors
+
+        const errorsToAppend = jsonStats.errors
         // remove stack trace lines since they're useless for debugging
         .map((err) => err.replace(/\n\s*at.*/g, '').replace(/From previous event:\n?/g, ''))
         // multiple errors separated by newline
-        .join('\n\n')}`
+        .join('\n\n')
+
+        err.message += `\n${errorsToAppend}`
 
         return rejectWithErr(err)
       }

--- a/index.js
+++ b/index.js
@@ -108,8 +108,6 @@ const preprocessor = (options = {}) => {
 
     const rejectWithErr = (err) => {
       err.filePath = filePath
-      // backup the original stack before it's potentially modified by bluebird
-      err.originalStack = err.stack
       debug(`errored bundling ${outputPath}`, err)
       latestBundle.reject(err)
     }
@@ -125,7 +123,11 @@ const preprocessor = (options = {}) => {
 
       if (stats.hasErrors()) {
         err = new Error('Webpack Compilation Error')
-        err.stack = jsonStats.errors.join('\n\n')
+        err.message += `\n${jsonStats.errors
+        // remove stack trace lines since they're useless for debugging
+        .map((err) => err.replace(/\n\s*at.*/g, '').replace(/From previous event:\n?/g, ''))
+        // multiple errors separated by newline
+        .join('\n\n')}`
 
         return rejectWithErr(err)
       }

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -65,12 +65,16 @@ exports.runTest = async (options = {}) => {
     expectedResults: {
       totalFailed: 0,
     },
-    expectedStdout: null,
+    stdoutInclude: null,
     browser: 'electron',
     exit: true,
   })
 
   _.merge(opts, parsedSpecOptions)
+
+  if (_.isString(opts.stdoutInclude)) {
+    opts.stdoutInclude = [opts.stdoutInclude]
+  }
 
   console.log(chalk.cyanBright(`starting test run: ${opts.spec}`))
 
@@ -106,8 +110,8 @@ exports.runTest = async (options = {}) => {
     expect(res).includes(opts.expectedResults)
   })
   .then(() => {
-    if (opts.expectedStdout) {
-      _.forEach(opts.expectedStdout, (v) => {
+    if (opts.stdoutInclude) {
+      _.forEach(opts.stdoutInclude, (v) => {
         expect(stdout).include(v)
         console.log(`${chalk.bold('run matched stdout:')}\n${v}`)
       })

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -273,8 +273,9 @@ describe('webpack preprocessor', function () {
         })
       })
 
-      it('it rejects with joined errors when a stats err', function () {
-        const errs = ['foo', 'bar', 'baz']
+      it('it rejects with joined errors when a stats err and strips stacktrace', function () {
+        const errs = ['foo\nat Object.foo', 'bar', 'baz']
+        const errsNoStack = ['foo', 'bar', 'baz']
 
         this.statsApi = {
           hasErrors () {
@@ -288,15 +289,7 @@ describe('webpack preprocessor', function () {
         this.compilerApi.run.yields(null, this.statsApi)
 
         return this.run().catch((err) => {
-          expect(err.stack).to.equal(errs.join('\n\n'))
-        })
-      })
-
-      it('backs up stack as originalStack', function () {
-        this.compilerApi.run.yields(this.err)
-
-        return this.run().catch((err) => {
-          expect(err.originalStack).to.equal(this.err.stack)
+          expect(err.message).to.equal(`Webpack Compilation Error\n${errsNoStack.join('\n\n')}`)
         })
       })
     })


### PR DESCRIPTION
append error to error.message instead of error.stack
- this fixes strange issue where the stack will not contain the code-frame and only keep the stacktrace
- also fixes issue with `Error: Webpack Compilation Error` not showing up in the error
- makes hack around `e.originalStack` unnecessary 

fix #64 