### PR TITLE
describe how to use your own babelrc

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,6 @@ examples/react-app/node_modules
 examples/react-app/build
 examples/react-app/package.json
 examples/react-app/cypress/integration/dynamic-import-spec.js
+# contains nullish operator
+examples/use-babelrc/cypress/integration/spec.js
 *.ts

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ module.exports = (on) => {
 Pass in options as the second argument to `webpack`:
 
 ```javascript
-const webpack = require('@cypress/webpack-preprocessor')
+const webpackPreprocessor = require('@cypress/webpack-preprocessor')
 
 module.exports = (on) => {
   const options = {
@@ -61,7 +61,7 @@ module.exports = (on) => {
     watchOptions: {},
   }
 
-  on('file:preprocessor', webpack(options))
+  on('file:preprocessor', webpackPreprocessor(options))
 }
 ```
 
@@ -91,6 +91,19 @@ Object of webpack options. Just `require` in the options from your `webpack.conf
 ```
 
 Source maps are always enabled unless explicitly disabled by specifying `devtool: false`.
+
+### use babelrc
+
+If you have a `.babelrc` file and would like to use it, then you must delete `options.presets` from the default Webpack options
+
+```js
+const webpackPreprocessor = require('@cypress/webpack-preprocessor')
+const defaults = webpackPreprocessor.defaultOptions
+module.exports = (on) => {
+  delete defaults.webpackOptions.module.rules[0].use[0].options.presets
+  on('file:preprocessor', webpackPreprocessor(defaults))
+}
+```
 
 ### watchOptions
 

--- a/circle.yml
+++ b/circle.yml
@@ -46,6 +46,16 @@ workflows:
           no-workspace: true
           working_directory: examples/react-app
 
+      - cypress/run:
+          name: Test babelrc
+          requires:
+            - Install
+          executor: cypress/base-12-14-0
+          install-command: echo 'Nothing else to install in this job'
+          timeout: '1m'
+          no-workspace: true
+          working_directory: examples/use-babelrc
+
       # wait for all jobs to finish and possible run NPM release
       - cypress/run:
           name: NPM release
@@ -53,6 +63,7 @@ workflows:
             - Install
             - Tests
             - Test React App
+            - Test babelrc
           executor: cypress/base-12-14-0
           # nothing to install - cypress/install job does it
           # and nothing to pass to the next job

--- a/examples/use-babelrc/.babelrc
+++ b/examples/use-babelrc/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "@babel/plugin-proposal-nullish-coalescing-operator"
+  ]
+}

--- a/examples/use-babelrc/.eslintrc.json
+++ b/examples/use-babelrc/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "cypress/globals": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:cypress/recommended"
+  ],
+  "plugins": ["cypress"]
+}

--- a/examples/use-babelrc/README.md
+++ b/examples/use-babelrc/README.md
@@ -1,0 +1,19 @@
+# use-babelrc
+
+> Transpiling specs using local .babelrc file
+
+The [cypress/integration/spec.js](cypress/integration/spec.js) uses null coalescing operator `??`, which needs a [separate plugin](https://babeljs.io/docs/en/next/babel-plugin-proposal-nullish-coalescing-operator) for Babel to transpile it.
+
+```js
+it('handles nullish operator', () => {
+  const data = {
+    person: {
+      firstName: 'Joe'
+    }
+  }
+  const name = data.person.firstName ?? 'Anonymous'
+  expect(name).to.equal('Joe')
+})
+```
+
+There is a local [.babelrc](.babelrc) file, and to make Cypress preprocessor use it, the [cypress/plugins/index.js](cypress/plugins/index.js) removes Babel presets from the default options.

--- a/examples/use-babelrc/cypress.json
+++ b/examples/use-babelrc/cypress.json
@@ -1,0 +1,4 @@
+{
+  "fixturesFolder": false,
+  "supportFile": false
+}

--- a/examples/use-babelrc/cypress/integration/spec.js
+++ b/examples/use-babelrc/cypress/integration/spec.js
@@ -1,0 +1,12 @@
+/// <reference types="cypress" />
+describe('Use .babelrc', () => {
+  it('handles nullish operator', () => {
+    const data = {
+      person: {
+        firstName: 'Joe'
+      }
+    }
+    const name = data.person.firstName ?? 'Anonymous'
+    expect(name).to.equal('Joe')
+  })
+})

--- a/examples/use-babelrc/cypress/plugins/index.js
+++ b/examples/use-babelrc/cypress/plugins/index.js
@@ -1,0 +1,7 @@
+const webpackPreprocessor = require('../../../..')
+const defaults = webpackPreprocessor.defaultOptions
+
+module.exports = (on) => {
+  delete defaults.webpackOptions.module.rules[0].use[0].options.presets
+  on('file:preprocessor', webpackPreprocessor(defaults))
+}

--- a/examples/use-babelrc/package.json
+++ b/examples/use-babelrc/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "use-babelrc",
+  "version": "1.0.0",
+  "description": "Transpiling specs using local .babelrc file",
+  "private": true,
+  "scripts": {
+    "test": "../../node_modules/.bin/cypress run",
+    "cy:open": "../../node_modules/.bin/cypress open"
+  },
+  "license": "ISC",
+  "author": "",
+  "keywords": []
+}

--- a/examples/use-babelrc/package.json
+++ b/examples/use-babelrc/package.json
@@ -4,8 +4,8 @@
   "description": "Transpiling specs using local .babelrc file",
   "private": true,
   "scripts": {
-    "test": "../../node_modules/.bin/cypress run",
-    "cy:open": "../../node_modules/.bin/cypress open"
+    "cy:open": "../../node_modules/.bin/cypress open",
+    "test": "../../node_modules/.bin/cypress run"
   },
   "license": "ISC",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.1",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "7.8.3",
     "@babel/preset-env": "^7.0.0",
     "@cypress/eslint-plugin-dev": "5.0.0",
     "@typescript-eslint/eslint-plugin": "2.27.0",


### PR DESCRIPTION
- closes #77
- [x] add blurb to README describing how to delete presets to let Webpack load `.babelrc` file instead
- [x] add full example in `examples` folder

Related (more robust delete) in https://github.com/bahmutov/cypress-react-unit-test/blob/master/plugins/babelrc/file-preprocessor.js